### PR TITLE
feat: make install script argument mandatory

### DIFF
--- a/x/bash.sh
+++ b/x/bash.sh
@@ -18,28 +18,34 @@ usage() {
 		for more information.
 
 		Synopsis:
-		  $cmd [-hs]
+		  $cmd -S [-s]
+		  $cmd -h
+
+		Commands:
+		  -S  Start shell.
+		  -h  Show help and exit.
 
 		Options:
-		  -h  Show help and exit.
 		  -s  Skip GPG key import.
 
 		Examples:
-		  bash <(curl -s https://mtth.github.io/x/bash.sh)
+		  bash <(curl -s https://mtth.github.io/x/bash.sh) -S
 	EOF
 	exit "${1:-2}"
 }
 
 main() {
-	local import_key=1 opt
-	while getopts :hs opt "$@"; do
+	local cmd='' import_key=1 opt
+	while getopts :Shs opt "$@"; do
 		case "$opt" in
+			S) cmd=start ;;
 			h) usage 0 ;;
 			s) import_key=0 ;;
 			*) fail "unknown option: $OPTARG" ;;
 		esac
 	done
 	shift $(( OPTIND-1 ))
+	[[ -n $cmd ]] || usage 2
 
 	if (( import_key )); then
 		gpg --keyserver hkps://keys.openpgp.org --recv-keys "$gpg_fingerprint"

--- a/x/dotfiles.sh
+++ b/x/dotfiles.sh
@@ -20,12 +20,12 @@ usage() {
 		more information.
 
 		Synopsis:
-		  $name [-Ikmd PATH]
+		  $name -I [-kmd PATH]
 		  $name -V [-kp PAGER] [PATTERN]
 		  $name -h
 
 		Commands:
-		  -I  Install dotfiles. This is the default command.
+		  -I  Install dotfiles.
 		  -V  View the files matching PATTERN within the .files/ folder. If PATTERN
 		      is omitted, the list of file names is displayed.
 		  -h  Show help and exit.
@@ -37,14 +37,14 @@ usage() {
 		  -p PAGER  Pager to use for viewing files. Defaults to $default_pager.
 
 		Examples:
-		  bash <(curl -s https://mtth.github.io/x/dotfiles.sh)
+		  bash <(curl -s https://mtth.github.io/x/dotfiles.sh) -I
 	EOF
 	exit "${1:-2}"
 }
 
 main() {
 	local \
-		cmd=INSTALL \
+		cmd='' \
 		import_key=0 pager="$default_pager" run_install=1 workdir="$HOME" \
 		opt
 	while getopts :IVd:hkmp: opt "$@"; do
@@ -60,6 +60,7 @@ main() {
 		esac
 	done
 	shift $(( OPTIND-1 ))
+	[[ -n $cmd ]] || usage 2
 
 	ensure_key
 


### PR DESCRIPTION
This protects against unindented installation when running these scripts for the first time, typically via `curl`.